### PR TITLE
Fix startMoving call condition

### DIFF
--- a/lib/plugins/gridmovement.js
+++ b/lib/plugins/gridmovement.js
@@ -46,7 +46,7 @@ ig.module(
                     this.continueMovingToDestination();
                 }
                 // Not moving, start moving
-                else if (this.isMoving && this.direction && this.canMoveDirectionFromCurrentTile(this.direction)) {
+                else if (!this.isMoving() && this.direction && this.canMoveDirectionFromCurrentTile(this.direction)) {
                     this.startMoving(this.direction);
                 }
 


### PR DESCRIPTION
this.isMoving is always true, because it returns a pointer to a function. We actually want to make sure that we're not moving. Small difference :)
