### PR TITLE
Fix canMoveDirectionFromTile when the new position is out of bound

### DIFF
--- a/lib/plugins/gridmovement.js
+++ b/lib/plugins/gridmovement.js
@@ -143,6 +143,11 @@ ig.module(
 
             canMoveDirectionFromTile:function (tileX, tileY, direction) {
                 var newPos = this.getTileAdjacentToTile(tileX, tileY, direction);
+                // return false if the new position is out of bound
+                if(!ig.game.collisionMap.data[Math.round(newPos.y)]) {
+                    return false;
+                }
+
                 return ig.game.collisionMap.data[Math.round(newPos.y)][Math.round(newPos.x)] === 0;
             },
 


### PR DESCRIPTION
Hi there!

The canMoveDirectionFromTile function was crashing when an entity tryed to move out of the level so i made a quick fix for this ;)