### PR TITLE
Add ability to go out of bounds.

### DIFF
--- a/lib/plugins/gridmovement.js
+++ b/lib/plugins/gridmovement.js
@@ -14,6 +14,7 @@ ig.module(
             lastTile:{},
             align:true,
             speed: {x: 75, y: 75},
+            canExitMap: false,
 
             init:function (entity) {
                 this.entity = entity;
@@ -29,16 +30,16 @@ ig.module(
                 if (this.isMoving() && this.justReachedDestination() && !this.direction) {
                     this.stopMoving();
                 }
-                // Stop moving if hitting a wall
-                else if (this.isMoving() && this.justReachedDestination() && this.direction && !this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction)) {
+                // Stop moving if hitting a wall?
+                else if (this.isMoving() && this.justReachedDestination() && this.direction && !this.canExitMap && !this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction)) {
                     this.stopMoving();
                 }
                 // Dest reached, but set a new dest and continue
-                else if (this.isMoving() && this.justReachedDestination() && this.direction && this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction) && this.direction === this.lastMove) {
+                else if (this.isMoving() && this.justReachedDestination() && this.direction && (this.canExitMap || this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction)) && this.direction === this.lastMove) {
                     this.continueMovingFromDestination();
                 }
                 // Dest reached but changing direction
-                else if (this.isMoving() && this.justReachedDestination() && this.direction && this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction) && this.direction !== this.lastMove) {
+                else if (this.isMoving() && this.justReachedDestination() && this.direction && (this.canExitMap || this.canMoveDirectionFromTile(this.destination.x, this.destination.y, this.direction)) && this.direction !== this.lastMove) {
                     this.changeDirectionAndContinueMoving(this.direction);
                 }
                 // Dest not reached, continue
@@ -46,10 +47,9 @@ ig.module(
                     this.continueMovingToDestination();
                 }
                 // Not moving, start moving
-                else if (!this.isMoving() && this.direction && this.canMoveDirectionFromCurrentTile(this.direction)) {
+                else if (!this.isMoving() && this.direction && (this.canExitMap || this.canMoveDirectionFromCurrentTile(this.direction))) {
                     this.startMoving(this.direction);
                 }
-
 
                 this.direction = null;
                 this.lastTile = this.destination;


### PR DESCRIPTION
I've added out of (current map) bounds movement abilities to the plugin, if the user so chooses. To do so, set movement's (new) canExitMap flag to true...

```
this.movement = new GridMovement(this);
this.movement.canExitMap = true;
```

I hope this helps.
